### PR TITLE
Fix GRUB_DISTRIBUTOR with necessary quotes

### DIFF
--- a/src/installer_core.py
+++ b/src/installer_core.py
@@ -126,7 +126,7 @@ def get_username():
 
 #   GRUB and EFI
 def grub_ash(v):
-    os.system(f"sudo sed -i 's/^GRUB_DISTRIBUTOR.*$/GRUB_DISTRIBUTOR={distro_name}/' -i /mnt/etc/default/grub") ### -i
+    os.system(f"sudo sed -i 's/^GRUB_DISTRIBUTOR.*$/GRUB_DISTRIBUTOR=\"{distro_name}\"/' /mnt/etc/default/grub")
     if is_luks:
         os.system("sudo sed -i 's/^#GRUB_ENABLE_CRYPTODISK.*$/GRUB_ENABLE_CRYPTODISK=y/' -i /mnt/etc/default/grub") ### -i
         os.system(f"sudo sed -i -E 's|^#?GRUB_CMDLINE_LINUX=\"|GRUB_CMDLINE_LINUX=\"cryptdevice=UUID={to_uuid(args[1])}:luks_root cryptkey=rootfs:/etc/crypto_keyfile.bin|' /mnt/etc/default/grub")


### PR DESCRIPTION
This was first exposed when installing in BIOS mode, which would render system not bootable!
(this actually applied to UEFI too, but because of nature of UEFI, system was still booting!)