### PR TITLE
add option to retry download

### DIFF
--- a/src/distros/arch/installer.py
+++ b/src/distros/arch/installer.py
@@ -55,7 +55,7 @@ else:
 if excode != 0:
     sys.exit("Failed to bootstrap!")
 if is_efi:
-    excode = pacstrap(packages)
+    excode = pacstrap("efibootmgr")
     if excode != 0:
         sys.exit("Failed to download packages!")
 


### PR DESCRIPTION
Unfortunately pacman isn't super stable, especially on an unstable network. Currently a download error in pacstrap causes a complete installation failure, so a full rerun of the installer is needed. This commit adresses the issue.